### PR TITLE
Add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.gradle
+build
+


### PR DESCRIPTION
Hi,

From https://github.com/openjournals/joss-reviews/issues/2791

Do you prefer that devs/users building s4rdm3x use `~/.gitignore`, or would a `.gitignore` in the repository be OK?

Adding just in case of the latter. My git working copy had these two files from my last tests.

Thanks
Bruno