### PR TITLE
Add prerequisites for installation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,10 @@ A command line tool for executing experiments in parrallell. It reads an experim
 # Installation
 Download the latest [Release](https://github.com/tobias-dv-lnu/s4rdm3x/releases) from GitHub, it includes precompiled versions of the tools as jar applications for all plattforms.
 
+# Prerequisites
+
+- Java 11 or superior
+
 # Running
 Run via commandline:
 


### PR DESCRIPTION
Hi!

From https://github.com/openjournals/joss-reviews/issues/2791

I am still using Java 8 by default, but have up to Java 15 installed. When I tried `java -jar ...jar`, I got

```
$ java -jar v3xt.jar 
Exception in thread "main" java.lang.UnsupportedClassVersionError: uno/glfw/glfw has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:763)
	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
	at java.net.URLClassLoader.defineClass(URLClassLoader.java:468)
	at java.net.URLClassLoader.access$100(URLClassLoader.java:74)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:369)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:363)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.net.URLClassLoader.findClass(URLClassLoader.java:362)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at Main.<init>(Main.java:41)
	at Main.main(Main.java:52)
```

Couldn't remember what was the `55` class file version, so randomly tried Java 11, and it worked. Checked the class file versions, it looks like that's Java 11, so I've added a section for the prerequisites (only Java for now).